### PR TITLE
Add teacher-only admin mode for activity management

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,19 +5,43 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+import json
 import os
+import secrets
 from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
+teachers_file = current_dir / "teachers.json"
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_teachers():
+    with teachers_file.open("r", encoding="utf-8") as handle:
+        teacher_data = json.load(handle)
+
+    return {
+        teacher["username"]: teacher["password"]
+        for teacher in teacher_data.get("teachers", [])
+    }
+
+
+teachers = load_teachers()
+teacher_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -78,6 +102,16 @@ activities = {
 }
 
 
+def require_teacher(request: Request):
+    session_token = request.cookies.get("teacher_session")
+    username = teacher_sessions.get(session_token)
+
+    if not username:
+        raise HTTPException(status_code=403, detail="Teacher login required")
+
+    return username
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,9 +122,57 @@ def get_activities():
     return activities
 
 
+@app.get("/auth/session")
+def get_session(request: Request):
+    session_token = request.cookies.get("teacher_session")
+    username = teacher_sessions.get(session_token)
+
+    if not username:
+        return {"authenticated": False}
+
+    return {"authenticated": True, "username": username}
+
+
+@app.post("/auth/login")
+def login_teacher(payload: LoginRequest):
+    expected_password = teachers.get(payload.username)
+
+    if expected_password != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    session_token = secrets.token_urlsafe(32)
+    teacher_sessions[session_token] = payload.username
+
+    response = JSONResponse({
+        "message": f"Logged in as {payload.username}",
+        "username": payload.username,
+    })
+    response.set_cookie(
+        key="teacher_session",
+        value=session_token,
+        httponly=True,
+        samesite="lax",
+    )
+    return response
+
+
+@app.post("/auth/logout")
+def logout_teacher(request: Request):
+    session_token = request.cookies.get("teacher_session")
+
+    if session_token:
+        teacher_sessions.pop(session_token, None)
+
+    response = JSONResponse({"message": "Logged out"})
+    response.delete_cookie("teacher_session")
+    return response
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, request: Request):
     """Sign up a student for an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +193,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, request: Request):
     """Unregister a student from an activity"""
+    require_teacher(request)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,77 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const accountToggle = document.getElementById("account-toggle");
+  const accountPanel = document.getElementById("account-panel");
+  const accountStatus = document.getElementById("account-status");
+  const loginTrigger = document.getElementById("login-trigger");
+  const logoutTrigger = document.getElementById("logout-trigger");
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginModal = document.getElementById("close-login-modal");
+  const loginForm = document.getElementById("login-form");
+  const teacherHelper = document.getElementById("teacher-helper");
+
+  let authState = {
+    authenticated: false,
+    username: null,
+  };
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = `message ${type}`;
+    messageDiv.classList.remove("hidden");
+
+    window.clearTimeout(showMessage.timeoutId);
+    showMessage.timeoutId = window.setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUi() {
+    accountStatus.textContent = authState.authenticated
+      ? `Logged in as ${authState.username}`
+      : "Viewing as student";
+
+    loginTrigger.classList.toggle("hidden", authState.authenticated);
+    logoutTrigger.classList.toggle("hidden", !authState.authenticated);
+
+    signupForm.querySelectorAll("input, select, button").forEach((field) => {
+      field.disabled = !authState.authenticated;
+    });
+
+    teacherHelper.textContent = authState.authenticated
+      ? "Teacher mode is active. You can register or remove students."
+      : "Students can view activity rosters. Teachers must log in to register or remove students.";
+  }
+
+  async function refreshSession() {
+    try {
+      const response = await fetch("/auth/session");
+      const session = await response.json();
+
+      authState = {
+        authenticated: Boolean(session.authenticated),
+        username: session.username || null,
+      };
+    } catch (error) {
+      authState = {
+        authenticated: false,
+        username: null,
+      };
+      console.error("Error checking session:", error);
+    }
+
+    updateAuthUi();
+  }
+
+  function setAccountPanelOpen(isOpen) {
+    accountPanel.classList.toggle("hidden", !isOpen);
+    accountToggle.setAttribute("aria-expanded", String(isOpen));
+  }
+
+  function setLoginModalOpen(isOpen) {
+    loginModal.classList.toggle("hidden", !isOpen);
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +83,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +102,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        authState.authenticated
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -86,26 +162,18 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 403) {
+          await refreshSession();
+        }
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -130,31 +198,110 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        if (response.status === 403) {
+          await refreshSession();
+        }
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  accountToggle.addEventListener("click", () => {
+    const isOpen = accountToggle.getAttribute("aria-expanded") === "true";
+    setAccountPanelOpen(!isOpen);
+  });
+
+  loginTrigger.addEventListener("click", () => {
+    setAccountPanelOpen(false);
+    setLoginModalOpen(true);
+  });
+
+  closeLoginModal.addEventListener("click", () => {
+    setLoginModalOpen(false);
+  });
+
+  logoutTrigger.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/auth/logout", {
+        method: "POST",
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Unable to log out.", "error");
+        return;
+      }
+
+      authState = {
+        authenticated: false,
+        username: null,
+      };
+      updateAuthUi();
+      await fetchActivities();
+      setAccountPanelOpen(false);
+      showMessage(result.message, "success");
+    } catch (error) {
+      showMessage("Unable to log out.", "error");
+      console.error("Error logging out:", error);
+    }
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Unable to log in.", "error");
+        return;
+      }
+
+      authState = {
+        authenticated: true,
+        username: result.username,
+      };
+      updateAuthUi();
+      await fetchActivities();
+      loginForm.reset();
+      setLoginModalOpen(false);
+      showMessage(result.message, "success");
+    } catch (error) {
+      showMessage("Unable to log in.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!accountPanel.contains(event.target) && !accountToggle.contains(event.target)) {
+      setAccountPanelOpen(false);
+    }
+
+    if (event.target === loginModal) {
+      setLoginModalOpen(false);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  refreshSession().then(fetchActivities);
 });

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -206,6 +206,7 @@ document.addEventListener("DOMContentLoaded", () => {
       } else {
         if (response.status === 403) {
           await refreshSession();
+          await fetchActivities();
         }
         showMessage(result.detail || "An error occurred", "error");
       }

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,30 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-bar">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="account-menu">
+          <button
+            id="account-toggle"
+            class="icon-button"
+            type="button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-controls="account-panel"
+            aria-label="Account options"
+          >
+            <span aria-hidden="true">👤</span>
+          </button>
+          <div id="account-panel" class="account-panel hidden">
+            <p id="account-status">Viewing as student</p>
+            <button id="login-trigger" type="button">Log In</button>
+            <button id="logout-trigger" type="button" class="secondary-action hidden">Log Out</button>
+          </div>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -22,7 +44,10 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Teacher Registration Controls</h3>
+        <p id="teacher-helper" class="info-panel">
+          Students can view activity rosters. Teachers must log in to register or remove students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -40,6 +65,26 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3 id="login-title">Teacher Login</h3>
+          <button id="close-login-modal" type="button" class="icon-button" aria-label="Close login dialog">✕</button>
+        </div>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required autocomplete="current-password" />
+          </div>
+          <button type="submit">Log In</button>
+        </form>
+      </div>
+    </div>
 
     <footer>
       <p>&copy; 2026 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -24,8 +24,59 @@ header {
   border-radius: 5px;
 }
 
+.header-bar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 20px;
+  text-align: left;
+}
+
 header h1 {
   margin-bottom: 10px;
+}
+
+.account-menu {
+  position: relative;
+}
+
+.icon-button {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.account-panel {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 220px;
+  background-color: #fff;
+  color: #333;
+  border-radius: 8px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  padding: 16px;
+  z-index: 10;
+}
+
+.account-panel p {
+  margin-bottom: 12px;
+}
+
+.account-panel button,
+.modal-card button,
+.secondary-action {
+  width: 100%;
+}
+
+.secondary-action {
+  margin-top: 10px;
+  background-color: #455a64;
 }
 
 main {
@@ -55,6 +106,15 @@ section h3 {
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
   color: #1a237e;
+}
+
+.info-panel {
+  margin-bottom: 16px;
+  padding: 12px;
+  background-color: #e8eaf6;
+  border: 1px solid #c5cae9;
+  border-radius: 4px;
+  color: #283593;
 }
 
 .activity-card {
@@ -125,6 +185,11 @@ section h3 {
   background-color: #ffebee;
 }
 
+.delete-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .participants-section p {
   color: #777;
   font-style: italic;
@@ -164,6 +229,11 @@ button:hover {
   background-color: #3949ab;
 }
 
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -192,9 +262,51 @@ button:hover {
   display: none;
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal-card {
+  width: min(100%, 420px);
+  background-color: white;
+  border-radius: 10px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
+  padding: 20px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
 footer {
   text-align: center;
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+@media (max-width: 767px) {
+  .header-bar {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .account-menu {
+    align-self: center;
+  }
+
+  .account-panel {
+    right: 50%;
+    transform: translateX(50%);
+  }
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "mrivera",
+      "password": "mergington-admin-2026"
+    },
+    {
+      "username": "jsmith",
+      "password": "activity-roster-2026"
+    }
+  ]
+}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -2,11 +2,11 @@
   "teachers": [
     {
       "username": "mrivera",
-      "password": "mergington-admin-2026"
+      "password": "CHANGE_ME_SECURELY_IN_LOCAL_CONFIG"
     },
     {
       "username": "jsmith",
-      "password": "activity-roster-2026"
+      "password": "CHANGE_ME_SECURELY_IN_LOCAL_CONFIG"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add teacher login and logout endpoints backed by a JSON teacher list
- require an authenticated teacher session for signup and unregister actions
- add account controls in the UI so students can still view rosters but only teachers can modify them

## Testing
- validated changed files with editor diagnostics for Python, JS, HTML, and CSS
- manual runtime test was not completed because the terminal session was not usable in this environment

Closes #5